### PR TITLE
Update to save time on subsequent Docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Travis configuration
 - Updated Repgen ENV in Dockerfile to an ARG and defaulting it to "master"
+### Updated
+- Split up gsplot and repgen installations in Dockerfile. Moved repgen installation
+below gsplot. This allows faster subsequent builds when repgen changes but gsplot
+has not (typical case). Previously, gsplot and repgen were being downloaded and
+installed within the same two RUN blocks, causing extra time to reinstall gsplot
+when it is not necessary
 
 ## [0.0.3] - 2018-03-19
 ### Updated

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir ${RSERVE_HOME}/R_libs && \
   mkdir -p /tmp/install/gsplot_description_dir && \
   mkdir -p /tmp/install/repgen_description_dir
 
-RUN wget -O /tmp/install/gsplot_description_dir/DESCRIPTION https://raw.githubusercontent.com/USGS-R/gsplot/v${GSPLOT_VERSION}/DESCRIPTION
+RUN wget -O /tmp/install/gsplot_description_dir/DESCRIPTION https://raw.githubusercontent.com/USGS-R/gsplot/v${GSPLOT_VERSION}/DESCRIPTION && \
   Rscript /tmp/install/installPackages.R && \
   Rscript -e "library(devtools);install_url('https://github.com/USGS-R/gsplot/archive/v${GSPLOT_VERSION}.zip', dependencies = F)"
 


### PR DESCRIPTION
Split up gsplot and repgen installations in Dockerfile. Moved repgen installation
below gsplot. This allows faster subsequent builds when repgen changes but gsplot
has not (typical case). Previously, gsplot and repgen were being downloaded and
installed within the same two RUN blocks, causing extra time to reinstall gsplot
when it is not necessary