### PR TITLE
AQCU-1729: move gsplot install over to repgen container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN apt-get update && \
 ENV RSERVE_HOME /opt/rserve
 ENV R_LIBS ${RSERVE_HOME}/R_libs
 ENV PANDOC_VERSION_DEFAULT 1.19.2.1
-ENV REPGEN_VERSION=master
-ENV GSPLOT_VERSION_DEFAULT 0.8.1
 ENV USERNAME ${USERNAME:-rserve}
 ENV PASSWORD ${PASSWORD:-rserve}
 
@@ -56,19 +54,6 @@ RUN wget -O /tmp/oberdiek.tds.zip http://mirrors.ctan.org/install/macros/latex/c
 USER $USERNAME
 
 ARG CACHE_BREAK_DATE=2018-04-26
-
-# Get GSPlot dependency installs
-RUN mkdir -p /tmp/install/gsplot_description_dir && \
-  wget -O /tmp/install/installPackages.R https://raw.githubusercontent.com/USGS-R/repgen/${REPGEN_VERSION}/inst/extdata/installPackages.R && \
-  wget -O /tmp/install/gsplot_description_dir/DESCRIPTION https://raw.githubusercontent.com/USGS-R/gsplot/v${GSPLOT_VERSION:-$GSPLOT_VERSION_DEFAULT}/DESCRIPTION
-
-# Install GSplot
-RUN mkdir ${RSERVE_HOME}/R_libs && \
-  mkdir ${RSERVE_HOME}/work && \
-  cd /tmp/install/gsplot_description_dir && \
-  Rscript /tmp/install/installPackages.R && \
-  Rscript -e "library(devtools);install_url('https://github.com/USGS-R/gsplot/archive/v${GSPLOT_VERSION:-$GSPLOT_VERSION_DEFAULT}.zip', dependencies = F)" && \
-  rm -rf /tmp/install
 
 EXPOSE 6311
 


### PR DESCRIPTION
must be merged along with https://github.com/USGS-CIDA/docker-aqcu-repgen/pull/12